### PR TITLE
async/await support 

### DIFF
--- a/lib/configureWebpack.js
+++ b/lib/configureWebpack.js
@@ -31,7 +31,30 @@ function configureWebpack(options) {
                     loader: require.resolve('babel-loader'),
                     query: {
                         highlightCode: false,
-                        presets: [require.resolve('babel-preset-es2015')],
+                        babelrc: false,
+                        presets: [require.resolve('babel-preset-latest')],
+                        plugins: [
+                            // uses the https://github.com/facebook/regenerator module to transform async and generator functions.
+                            [require.resolve('babel-plugin-transform-regenerator'), {
+                                asyncGenerators: true, // true by default
+                                generators: true, // true by default
+
+                                // Async functions are converted to generators by babel-preset-latest
+                                async: false // true by default
+                            }],
+                            // Polyfills the runtime needed for async/await and generators
+                            [require.resolve('babel-plugin-transform-runtime'), {
+                                helpers: false,
+                                polyfill: false,
+                                regenerator: true,
+                                // Resolve the Babel runtime relative to the config.
+                                moduleName: Path.dirname(require.resolve('babel-runtime/package'))
+                            }],
+                            require.resolve('babel-plugin-transform-class-properties'),
+                            [require.resolve('babel-plugin-transform-object-rest-spread'), {
+                                useBuiltIns: true
+                            }],
+                        ]
                     },
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -18,29 +18,32 @@
   "author": "Geoff Goodman",
   "license": "MIT",
   "dependencies": {
-    "argparse": "^1.0.7",
+    "argparse": "^1.0.9",
     "async": "^2.1.4",
-    "babel-core": "^6.18.2",
-    "babel-loader": "^6.2.8",
+    "babel-core": "^6.21.0",
+    "babel-loader": "^6.2.10",
+    "babel-plugin-transform-class-properties": "^6.19.0",
+    "babel-plugin-transform-object-rest-spread": "^6.20.2",
+    "babel-plugin-transform-regenerator": "^6.21.0",
     "babel-plugin-transform-runtime": "^6.15.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-runtime": "^6.18.0",
+    "babel-preset-latest": "^6.16.0",
+    "babel-runtime": "^6.20.0",
     "chalk": "^1.1.3",
     "cli-table": "^0.3.1",
-    "glob": "^6.0.4",
+    "glob": "^7.1.1",
     "json-loader": "^0.5.4",
-    "lodash": "^4.9.0",
-    "memory-fs": "^0.3.0",
+    "lodash": "^4.17.4",
+    "memory-fs": "^0.4.1",
     "mkdirp": "^0.5.1",
     "raw-loader": "^0.5.1",
-    "readline-sync": "^1.3.1",
-    "rxjs": "^5.0.0-rc.4",
-    "semver": "^5.1.0",
-    "superagent": "^1.7.2",
-    "webpack": "^1.13.1"
+    "readline-sync": "^1.4.5",
+    "rxjs": "^5.0.3",
+    "semver": "^5.3.0",
+    "superagent": "^3.3.2",
+    "webpack": "^1.14.0"
   },
   "devDependencies": {
     "code": "^4.0.0",
-    "lab": "^11.2.1"
+    "lab": "^11.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtask-bundle",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Bundle your webtask scripts",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Modified the webpack configurator to use babel-preset-latest with few plugins (regenerator & runtime, class-properties and object-spread) to make it easier to write cleaner code with the webtasks.

working example:

```
function resolveAfterNSeconds(x, n) {
  return new Promise(resolve => {
    setTimeout(() => {
      resolve(x);
    }, n * 1000);
  });
}

async function add(x) {
  console.log('starting...');
  var a = await resolveAfterNSeconds(20, 5);
  console.log('hang on...');
  var b = await resolveAfterNSeconds(30, 5);
  console.log('ready!');
  return x + a + b;
}

module.exports = async function(ctx, cb) {
  const res = await add(10);
  console.log(res);
  cb(null, res);
};
```